### PR TITLE
Fix asciidoc support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir /projects ${HOME} && \
     done && \
     wget -qO- https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz | tar xvz -C /usr/local/bin && \
     chmod +x /usr/local/bin/vale && \
+    apk --no-cache --update --allow-untrusted add asciidoctor && \
     # Future word lists or config files can go here
     mkdir ${HOME}/vale
 


### PR DESCRIPTION
Add the asciidoctor package to the vale sidecar container. If it's not installed,
vale will look for it and return an error.

See eclipse/che#15856 and https://github.com/eclipse/che-plugin-registry/pull/375#pullrequestreview-353997239

Signed-off-by: Eric Williams <ericwill@redhat.com>