### PR TITLE
Fix bad build-publish.yaml

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -17,6 +17,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Docker build, tag, and push
         run: |
+          IMAGE_VERSION=$(cat VERSION)
+          SHORT_SHA1=$(git rev-parse --short HEAD)
           echo "Building version ${IMAGE_VERSION} of image ${IMAGE_NAME}"
           docker build -t ${IMAGE_NAME} .
           docker tag "${IMAGE_NAME}" "${IMAGE_NAME}:${IMAGE_VERSION}"
@@ -27,5 +29,3 @@ jobs:
           docker push "${IMAGE_NAME}:${IMAGE_VERSION}-${SHORT_SHA1}"
         env:
           IMAGE_NAME: quay.io/eclipse/che-sidecar-vale
-          IMAGE_VERSION: $(cat VERSION)
-          SHORT_SHA1: $(git rev-parse --short HEAD)


### PR DESCRIPTION
Move IMAGE_VERSION and SHORT_SHA1 into the run section.

Signed-off-by: Eric Williams <ericwill@redhat.com>